### PR TITLE
Fix bash `if` syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,10 @@ script:
   - pod lib lint
 
 after_success:
-  - if [ $RUN_TESTS == "YES" && $PUBLISH_COVERAGE == "YES"]; then
+  - if [ $RUN_TESTS == "YES" && $PUBLISH_COVERAGE == "YES" ]; then
       bash <(curl -s https://codecov.io/bash);
     fi
-  - if [ ! -z "${TRAVIS_TAG}" && $PUBLISH_DOCS == "YES"]; then
+  - if [ ! -z "${TRAVIS_TAG}" && $PUBLISH_DOCS == "YES" ]; then
       ./CI/publish-docs.sh;
     fi
 


### PR DESCRIPTION
The `if` statements are not effective, so the `./docs` was not created.

This causes deployment to fail.

https://github.com/travis-ci/travis-ci/issues/7834