### PR TITLE
Bump virgil-crypto-x to 7.2.0 (virgil-crypto-c 0.19.0-rc.12)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,23 +1,23 @@
 {
-  "pins" : [
+  "pins": [
     {
-      "identity" : "virgil-crypto-c",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
-      "state" : {
-        "revision" : "3f2c23f1f96832ee4e7c5639b44f22b86262bd3c",
-        "version" : "0.19.0-rc.11"
+      "identity": "virgil-crypto-c",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-c.git",
+      "state": {
+        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
+        "version": "0.19.0-rc.12"
       }
     },
     {
-      "identity" : "virgil-crypto-x",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-x.git",
-      "state" : {
-        "revision" : "7659a974eecb47343920c1ab95bfcecf438f538e",
-        "version" : "7.1.0"
+      "identity": "virgil-crypto-x",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-x.git",
+      "state": {
+        "revision": "c7d4c29164f0cd73d6365b2527cbcbc21a2bdce9",
+        "version": "7.2.0"
       }
     }
   ],
-  "version" : 2
+  "version": 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-x.git", exact: "7.1.0")
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-x.git", exact: "7.2.0")
     ],
 
     targets: [

--- a/VirgilSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilSDK.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,23 +1,23 @@
 {
-  "pins" : [
+  "pins": [
     {
-      "identity" : "virgil-crypto-c",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
-      "state" : {
-        "revision" : "3f2c23f1f96832ee4e7c5639b44f22b86262bd3c",
-        "version" : "0.19.0-rc.11"
+      "identity": "virgil-crypto-c",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-c.git",
+      "state": {
+        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
+        "version": "0.19.0-rc.12"
       }
     },
     {
-      "identity" : "virgil-crypto-x",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-x",
-      "state" : {
-        "revision" : "7659a974eecb47343920c1ab95bfcecf438f538e",
-        "version" : "7.1.0"
+      "identity": "virgil-crypto-x",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-x",
+      "state": {
+        "revision": "c7d4c29164f0cd73d6365b2527cbcbc21a2bdce9",
+        "version": "7.2.0"
       }
     }
   ],
-  "version" : 2
+  "version": 2
 }


### PR DESCRIPTION
## Summary

- Bump `virgil-crypto-x` from `7.1.0` → `7.2.0`
- Transitive `virgil-crypto-c` moves from `0.19.0-rc.11` → `0.19.0-rc.12`
- Picks up ML-KEM-768 ratchet fixes and `Round5 → ML-KEM-768` rename in `KeyPairType`

## Test plan

- [ ] All CI jobs pass